### PR TITLE
Feature: link scripts in index.html from scripts.json

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -81,6 +81,8 @@ module.exports = function (grunt) {
             },
             javascript: {
                 files: [
+                    "./scripts.json",
+
                     "./app/js/*.js",
                     "./app/js/**/*.js",
                     "./app/js/**/**/*.js",
@@ -89,7 +91,7 @@ module.exports = function (grunt) {
                     "./tests/unit/**/*.js",
                     "./tests/unit/**/**/*.js"
                 ],
-                tasks: ["test:development"]
+                tasks: ["sails-linker", "test:development"]
             }
         },
 
@@ -311,7 +313,32 @@ module.exports = function (grunt) {
                 }
             },
             dist: {}
-        }
+        },
+
+        "sails-linker": {
+            vendorJs: {
+                options: {
+                    startTag: '<!--VENDOR SCRIPTS-->',
+                    endTag: '<!--VENDOR SCRIPTS END-->',
+                    fileTmpl: '<script src="%s"></script>',
+                    appRoot: './app/'
+                },
+                files: {
+                    'app/index.html': "<%= config.vendorFiles %>"
+                }
+            },
+            appJs: {
+                options: {
+                    startTag: '<!--SCRIPTS-->',
+                    endTag: '<!--SCRIPTS END-->',
+                    fileTmpl: '<script src="%s"></script>',
+                    appRoot: './app/'
+                },
+                files: {
+                    'app/index.html': "<%= config.applicationFiles %>"
+                }
+            }
+         }
 
     });
 
@@ -330,6 +357,7 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-processhtml");
     grunt.loadNpmTasks("grunt-ng-constant");
     grunt.loadNpmTasks("grunt-bump");
+    grunt.loadNpmTasks("grunt-sails-linker");
 
     grunt.registerTask("build", [
         "clean:beforeBuild",
@@ -354,6 +382,7 @@ module.exports = function (grunt) {
     grunt.registerTask("server", [
         "less:development",
         "ngconstant",
+        "sails-linker",
         "connect:server",
         "watch:css"
     ]);
@@ -361,6 +390,7 @@ module.exports = function (grunt) {
     grunt.registerTask("serverjs", [
         "less:development",
         "ngconstant",
+        "sails-linker",
         "connect:server",
         "watch:javascript"
     ]);
@@ -368,6 +398,7 @@ module.exports = function (grunt) {
     grunt.registerTask("serverall", [
         "less:development",
         "ngconstant",
+        "sails-linker",
         "connect:server",
         "watch"
     ]);

--- a/app/index.html
+++ b/app/index.html
@@ -60,10 +60,16 @@
 
     <!--[if gte IE 8]><!-->
     <!-- build:js js/app.min.js -->
+
+    <!--from scripts.json-->
+    <!--VENDOR SCRIPTS-->
     <script src="components/angular/angular.js"></script>
     <script src="components/angular-route/angular-route.js"></script>
+    <!--VENDOR SCRIPTS END-->
 
     <script src="js/config/config.js"></script>
+
+    <!--SCRIPTS-->
     <script src="js/search/search.js"></script>
     <script src="js/search/controllers/SearchCtrl.js"></script>
     <script src="js/results/results.js"></script>
@@ -71,6 +77,7 @@
     <script src="js/version/version.js"></script>
     <script src="js/version/directives/appVersion.js"></script>
     <script src="js/app.js"></script>
+    <!--SCRIPTS END-->
     <!-- /build -->
     <!--<![endif]-->
 

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "grunt-processhtml": "~0.3.7",
     "grunt-protractor-runner": "~2.0.0",
     "grunt-protractor-webdriver": "~0.2.0",
+    "grunt-sails-linker": "^0.10.1",
     "grunt-template-jasmine-istanbul": "~0.3.3",
     "protractor": "~2.0.0",
     "yuidoc-bootstrap-theme": "~1.0.4"


### PR DESCRIPTION
This PR adds syncing scripts in index.html with scripts.json. This means they only need to be added once, in the scripts.json file.

Just avoids us having to input them into index.html aswell and would avoid issues of forgetting to add them to scripts.json.

Also added scripts.json to the watch task so they will be continually updated when running `grunt serverall` or `grunt serverjs`.