### PR TITLE
Feature: Re-add grunt-protractor-webdriver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,11 @@ env:
     - secure: hmu/VH1viA8oPFjxBrjvnLrNa0PnfXsIKMMv9ZmgpXthdhTtuReD9rPmbnFzNh9MyCkLSZcndJakpDu9SwHVDcs5eyV72fuXHW/0htyN9eNTMyShrNIpOJe6JUqMez7MxQU9J45IJGSvbyEfrbZ20mbGGzJ41KnEZ0IfwODPcMY=
 before_install:
   - npm install -g bower grunt-cli protractor
-  - webdriver-manager update
 install:
   - npm install
 script:
   - grunt test:development
   - grunt test
-  - nohup webdriver-manager start &
   - grunt e2e --ci
 after_success:
   - ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - secure: hmu/VH1viA8oPFjxBrjvnLrNa0PnfXsIKMMv9ZmgpXthdhTtuReD9rPmbnFzNh9MyCkLSZcndJakpDu9SwHVDcs5eyV72fuXHW/0htyN9eNTMyShrNIpOJe6JUqMez7MxQU9J45IJGSvbyEfrbZ20mbGGzJ41KnEZ0IfwODPcMY=
 before_install:
   - npm install -g bower grunt-cli protractor
+  - webdriver-manager update
 install:
   - npm install
 script:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -163,6 +163,14 @@ module.exports = function (grunt) {
       }
     },
 
+    protractor_webdriver: {
+      dist: {
+        options: {
+          command: 'webdriver-manager update && webdriver-manager start',
+        }
+      }
+    },
+
     protractor: {
       options: {
         keepAlive: false,
@@ -367,6 +375,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-contrib-yuidoc');
   grunt.loadNpmTasks('grunt-contrib-jasmine');
   grunt.loadNpmTasks('grunt-protractor-runner');
+  grunt.loadNpmTasks('grunt-protractor-webdriver');
   grunt.loadNpmTasks('grunt-processhtml');
   grunt.loadNpmTasks('grunt-ng-constant');
   grunt.loadNpmTasks('grunt-bump');
@@ -446,6 +455,7 @@ module.exports = function (grunt) {
     'copy',
     'processhtml:e2e',
     'connect:servertest',
+    'protractor_webdriver',
     'protractor:dist',
     'clean:afterTest'
   ]);

--- a/README.md
+++ b/README.md
@@ -230,7 +230,6 @@ Once you have ensured that the development web server hosting our application is
 and WebDriver is updated, you can run the end-to-end tests using the supplied grunt task:
 
 ```
-nohup webdriver-manager start &
 grunt e2e
 ```
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "grunt-ng-constant": "~1.1.0",
     "grunt-processhtml": "~0.3.7",
     "grunt-protractor-runner": "~2.1.0",
+    "grunt-protractor-webdriver": "~0.2.5",
     "grunt-sails-linker": "~0.10.1",
     "grunt-template-jasmine-istanbul": "~0.3.3",
     "protractor": "~2.5.1",


### PR DESCRIPTION
The problem with the `grunt-protractor-webdriver` module which was causing our tests to fail has been fixed so re-adding the module back as it's a much simpler to use it then update the webdriver manually.