### PR TITLE
Feature: Update gruntfile

### DIFF
--- a/.csslintrc
+++ b/.csslintrc
@@ -8,5 +8,6 @@
   "outline-none": false,
   "regex-selectors": false,
   "shorthand": false,
-  "unique-headings": false
+  "unique-headings": false,
+  "qualified-headings": false
 }

--- a/.htmllintrc
+++ b/.htmllintrc
@@ -8,5 +8,6 @@
   "attr-req-value": false,
   "html-req-lang": true,
   "title-max-length": 120,
-  "img-req-src": false
+  "img-req-src": false,
+  "tag-bans": ["!style"]
 }

--- a/.htmllintrc
+++ b/.htmllintrc
@@ -7,5 +7,6 @@
   "line-end-style": "lf",
   "attr-req-value": false,
   "html-req-lang": true,
-  "title-max-length": 120
+  "title-max-length": 120,
+  "img-req-src": false
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ before_install:
 install:
   - npm install
 script:
+  - grunt lint
   - grunt test:development
   - grunt test
   - grunt e2e --ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ install:
   - npm install
 script:
   - grunt lint
-  - grunt test:development
-  - grunt test
-  - grunt e2e --ci
+  - grunt test:unit:development
+  - grunt test:unit:production
+  - grunt test:e2e --ci
 after_success:
   - ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info
 addons:

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,13 +61,9 @@ module.exports = function (grunt) {
         nospawn: false,
         livereload: true
       },
-      css: {
+      html: {
         files: [
           './app/index.html',
-
-          './app/less/*.less',
-          './app/less/**/*.less',
-          './app/less/**/**/*.less',
 
           './app/partials/*.html',
           './app/partials/**/*.html',
@@ -77,12 +73,18 @@ module.exports = function (grunt) {
           './modules/**/*.html',
           './modules/**/**/*.html'
         ],
-        tasks: ['lint','less:development']
+        tasks: ['htmllint']
+      },
+      css: {
+        files: [
+          './app/less/*.less',
+          './app/less/**/*.less',
+          './app/less/**/**/*.less'
+        ],
+        tasks: ['lesslint','less:development']
       },
       javascript: {
         files: [
-          './scripts.json',
-
           './app/js/*.js',
           './app/js/**/*.js',
           './app/js/**/**/*.js',
@@ -91,7 +93,13 @@ module.exports = function (grunt) {
           './tests/unit/**/*.js',
           './tests/unit/**/**/*.js'
         ],
-        tasks: ['sails-linker', 'test:development']
+        tasks: ['test:development'],
+      },
+      scriptsJson: {
+        files: [
+          './scripts.json'
+        ],
+        tasks: ['sails-linker'],
       }
     },
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -422,10 +422,6 @@ module.exports = function (grunt) {
     'watch'
   ]);
 
-  grunt.registerTask('serverall', [
-    'server'
-  ]);
-
   grunt.registerTask('precompile', [
     'less:development',
     'ngconstant',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -7,8 +7,8 @@ module.exports = function (grunt) {
   var base = grunt.option('base-dir') || '',
       env = grunt.option('env') || 'development',
       protractorConf = grunt.option('ci') ?
-        './tests/e2e/protractor.saucelabs.conf.js' :
-        './tests/e2e/protractor.conf.js' ;
+                      './tests/e2e/protractor.saucelabs.conf.js':
+                      './tests/e2e/protractor.conf.js';
 
   grunt.initConfig({
 
@@ -35,8 +35,8 @@ module.exports = function (grunt) {
           livereload: true,
           middleware: function ( connect, options, middlewares ) {
             var rules = (base === 'dist') ?
-                [ '^/[^\.]*$ /index.html' ] :
-            [ '^/app/[^\.]*$ /app/index.html' ];
+                        [ '^/[^\.]*$ ./index.html' ] :
+                        [ '^/app/[^\.]*$ ./app/index.html' ];
             middlewares.unshift( modRewrite( rules ) );
             return middlewares;
           }
@@ -48,7 +48,7 @@ module.exports = function (grunt) {
           livereload: false,
           base: '<%= config.outputDir %>',
           middleware: function ( connect, options, middlewares ) {
-            var rules = [ '^/[^\.]*$ /index.html' ];
+            var rules = [ '^/[^\.]*$ ./index.html' ];
             middlewares.unshift( modRewrite( rules ) );
             return middlewares;
           }
@@ -58,7 +58,7 @@ module.exports = function (grunt) {
 
     watch: {
       options: {
-        nospawn: false,
+        spawn: true,
         livereload: true
       },
       html: {
@@ -85,6 +85,10 @@ module.exports = function (grunt) {
       },
       javascript: {
         files: [
+          './app/data/*.json',
+          './app/data/**/*.json',
+          './app/data/**/**/*.json',
+
           './app/js/*.js',
           './app/js/**/*.js',
           './app/js/**/**/*.js',
@@ -93,13 +97,41 @@ module.exports = function (grunt) {
           './tests/unit/**/*.js',
           './tests/unit/**/**/*.js'
         ],
-        tasks: ['test:development'],
+        tasks: ['test:development']
       },
       scriptsJson: {
         files: [
           './scripts.json'
         ],
-        tasks: ['sails-linker'],
+        tasks: ['sails-linker']
+      },
+      refresh: {
+        files: [
+          './app/index.html',
+
+          './app/data/*.json',
+          './app/data/**/*.json',
+          './app/data/**/**/*.json',
+
+          './app/less/*.less',
+          './app/less/**/*.less',
+          './app/less/**/**/*.less',
+
+          './app/partials/*.html',
+          './app/partials/**/*.html',
+          './app/partials/**/**/*.html',
+
+          './app/js/*.js',
+          './app/js/**/*.js',
+          './app/js/**/**/*.js',
+
+          './modules/*.html',
+          './modules/**/*.html',
+          './modules/**/**/*.html',
+
+          './scripts.json'
+        ],
+        tasks: ['precompile']
       }
     },
 
@@ -259,10 +291,7 @@ module.exports = function (grunt) {
     },
 
     clean: {
-      beforeBuild: {
-        src: ['<%= config.outputDir %>', './docs']
-      },
-      afterTest: {
+      dist: {
         src: ['<%= config.outputDir %>']
       }
     },
@@ -402,7 +431,7 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-htmllint');
 
   grunt.registerTask('build', [
-    'clean:beforeBuild',
+    'clean:dist',
     'less:production',
     'ngconstant',
     'minify',
@@ -416,57 +445,50 @@ module.exports = function (grunt) {
     'bump-commit'
   ]);
 
+  grunt.registerTask('server', [
+    'precompile',
+    'connect:server',
+    'watch:refresh'
+  ]);
+
+  grunt.registerTask('serverall', [
+    'precompile',
+    'connect:server',
+    'watch'
+  ]);
+
+  grunt.registerTask('precompile', [
+    'less:development',
+    'ngconstant',
+    'sails-linker'
+  ]);
+
+  grunt.registerTask('lint', [
+    'htmllint',
+    'lesslint',
+    'jshint'
+  ]);
+
   grunt.registerTask('minify', [
     'concat',
     'uglify'
   ]);
 
-  grunt.registerTask('server', [
-    'less:development',
-    'ngconstant',
-    'sails-linker',
-    'connect:server',
-    'watch:css'
-  ]);
-
-  grunt.registerTask('serverjs', [
-    'less:development',
-    'ngconstant',
-    'sails-linker',
-    'connect:server',
-    'watch:javascript'
-  ]);
-
-  grunt.registerTask('serverall', [
-    'less:development',
-    'ngconstant',
-    'sails-linker',
-    'connect:server',
-    'watch'
-  ]);
-
-  grunt.registerTask('lint', [
-    'htmllint',
-    'lesslint'
-  ]);
-
   grunt.registerTask('test', [
-    'clean:beforeBuild',
+    'clean:dist',
     'ngconstant',
     'minify',
-    'jshint',
     'jasmine:production',
-    'clean:afterTest'
+    'clean:dist'
   ]);
 
   grunt.registerTask('test:development', [
     'ngconstant',
-    'jshint',
     'jasmine:development'
   ]);
 
   grunt.registerTask('e2e', [
-    'clean:beforeBuild',
+    'clean:dist',
     'less:production',
     'ngconstant',
     'minify',
@@ -475,7 +497,7 @@ module.exports = function (grunt) {
     'connect:servertest',
     'protractor_webdriver',
     'protractor:dist',
-    'clean:afterTest'
+    'clean:dist'
   ]);
 
   grunt.registerTask('default', ['build']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -393,7 +393,6 @@ module.exports = function (grunt) {
      */
     htmllint: {
       options: {
-        force: true,
         htmllintrc: '.htmllintrc'
       },
       src: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -104,34 +104,6 @@ module.exports = function (grunt) {
           './scripts.json'
         ],
         tasks: ['sails-linker']
-      },
-      refresh: {
-        files: [
-          './app/index.html',
-
-          './app/data/*.json',
-          './app/data/**/*.json',
-          './app/data/**/**/*.json',
-
-          './app/less/*.less',
-          './app/less/**/*.less',
-          './app/less/**/**/*.less',
-
-          './app/partials/*.html',
-          './app/partials/**/*.html',
-          './app/partials/**/**/*.html',
-
-          './app/js/*.js',
-          './app/js/**/*.js',
-          './app/js/**/**/*.js',
-
-          './modules/*.html',
-          './modules/**/*.html',
-          './modules/**/**/*.html',
-
-          './scripts.json'
-        ],
-        tasks: ['precompile']
       }
     },
 
@@ -447,13 +419,11 @@ module.exports = function (grunt) {
   grunt.registerTask('server', [
     'precompile',
     'connect:server',
-    'watch:refresh'
+    'watch'
   ]);
 
   grunt.registerTask('serverall', [
-    'precompile',
-    'connect:server',
-    'watch'
+    'server'
   ]);
 
   grunt.registerTask('precompile', [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -97,7 +97,7 @@ module.exports = function (grunt) {
           './tests/unit/**/*.js',
           './tests/unit/**/**/*.js'
         ],
-        tasks: ['test:development']
+        tasks: ['test:unit:development']
       },
       scriptsJson: {
         files: [
@@ -428,18 +428,23 @@ module.exports = function (grunt) {
     'sails-linker'
   ]);
 
+  grunt.registerTask('minify', [
+    'concat',
+    'uglify'
+  ]);
+
   grunt.registerTask('lint', [
     'htmllint',
     'lesslint',
     'jshint'
   ]);
 
-  grunt.registerTask('minify', [
-    'concat',
-    'uglify'
+  grunt.registerTask('test:unit:development', [
+    'ngconstant',
+    'jasmine:development'
   ]);
 
-  grunt.registerTask('test', [
+  grunt.registerTask('test:unit:production', [
     'clean:dist',
     'ngconstant',
     'minify',
@@ -447,12 +452,7 @@ module.exports = function (grunt) {
     'clean:dist'
   ]);
 
-  grunt.registerTask('test:development', [
-    'ngconstant',
-    'jasmine:development'
-  ]);
-
-  grunt.registerTask('e2e', [
+  grunt.registerTask('test:e2e', [
     'clean:dist',
     'less:production',
     'ngconstant',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -353,7 +353,7 @@ module.exports = function (grunt) {
       options: {
         imports: ['app/less/**/*.less'],
         csslint: {
-          csslintrc: './app/less/.csslintrc',
+          csslintrc: '.csslintrc',
         }
       }
     },
@@ -365,9 +365,19 @@ module.exports = function (grunt) {
     htmllint: {
       options: {
         force: true,
-        htmllintrc: './app/partials/.htmllintrc'
+        htmllintrc: '.htmllintrc'
       },
-      src: ['./app/*.html','./app/partials/**/*.html']
+      src: [
+        './app/index.html',
+
+        './app/partials/*.html',
+        './app/partials/**/*.html',
+        './app/partials/**/**/*.html',
+
+        './modules/*.html',
+        './modules/**/*.html',
+        './modules/**/**/*.html'
+      ]
     }
 
   });

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The angular-seed app comes preconfigured with unit tests. These are written in
 The easiest way to run the unit tests is to do:
 
 ```
-grunt test
+grunt test:unit:development
 ```
 
 This script will start the Jasmine test runner to execute the unit tests. You can also run:
@@ -216,7 +216,7 @@ Once you have ensured that the development web server hosting our application is
 and WebDriver is updated, you can run the end-to-end tests using the supplied grunt task:
 
 ```
-grunt e2e
+grunt test:e2e
 ```
 
 Behind the scenes this will also run `webdriver-manager update && webdriver-manager start`. This will download and install the latest version of the stand-alone WebDriver tool and start the Selenium web server. This script will execute the end-to-end tests against the application being hosted on the

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ And this will download the bootstrap package from bower and also update the `bow
 
 ### Run the Application
 
-We have preconfigured the project with a simple development web server.  The simplest way to start
+We have preconfigured the project with a simple development web server. The simplest way to start
 this server is:
 
 ```
@@ -88,21 +88,7 @@ grunt server
 
 Now browse to the app at `http://localhost:8000/app/`.
 
-If you are doing any javascript development you can instead run:
-
-```
-grunt serverjs
-```
-
-To run tests as well every time a javascript file is updated
-
-To watch all files run:
-
-```
-grunt serverall
-```
-
-To run tests or compile less to css when the relevent files are updated. 
+This command will watch all source files and run tests every time a javascript file is updated, compile less when a less file is updated and lint js/html/less files when they are updated.
 
 ### Running the build script
 

--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ grunt test
 This script will start the Jasmine test runner to execute the unit tests. You can also run:
 
 ```
-grunt serverjs
+grunt server
 ```
 
 Where the grunt watch command will sit and watch the source and test files for changes and then re-run the tests whenever any of them change.
-This is the recommended strategy; if you unit tests are being run every time you save a file then
+This is the recommended strategy; if your unit tests are being run every time you save a file then
 you receive instant feedback on any changes that break the expected code functionality.
 
 

--- a/app/index.html
+++ b/app/index.html
@@ -2,9 +2,7 @@
 <!-- build:[ng-app]:e2e myApp.e2e -->
 <!--[if lt IE 8]>      <html lang="en" ng-app="myApp" ng-strict-di class="no-js lt-ie9 lt-ie8"> <![endif]-->
 <!--[if IE 8]>         <html lang="en" ng-app="myApp" ng-strict-di class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!-->
-<html lang="en" ng-app="myApp" ng-strict-di class="no-js">
-<!--<![endif]-->
+<!--[if gt IE 8]><!--> <html lang="en" ng-app="myApp" ng-strict-di class="no-js"> <!--<![endif]-->
 <!-- /build -->
 
 <head>
@@ -44,12 +42,9 @@
   <meta name="theme-color" content="#ffffff">
 
 </head>
-
 <body>
 
-  <p class="text-right">App version:
-    <strong app-version></strong>
-  </p>
+  <p class="text-right">App version: <strong app-version></strong></p>
   <ng-view></ng-view>
 
   <!--[if lt IE 8]>
@@ -62,7 +57,6 @@
 
   <script>
     document.documentElement.className = document.documentElement.className.replace(/(^|\s)no-js(\s|$)/, "$1$2");
-
   </script>
 
   <!--[if gte IE 8]><!-->
@@ -88,11 +82,8 @@
   <!-- /build -->
   <!--<![endif]-->
 
-  <!-- build:js:e2e inline components/angular-mocks/angular-mocks.js -->
-  <!-- /build -->
-  <!-- build:js:e2e inline ../tests/e2e/app.e2e.js -->
-  <!-- /build -->
+  <!-- build:js:e2e inline components/angular-mocks/angular-mocks.js --> <!-- /build -->
+  <!-- build:js:e2e inline ../tests/e2e/app.e2e.js --> <!-- /build -->
 
 </body>
-
 </html>

--- a/app/partials/results.html
+++ b/app/partials/results.html
@@ -3,9 +3,7 @@
     <div class="col-md-12">
 
       <div class="page-header">
-        <h1>Results
-          <small class="badge">{{ results.length || 0 }}</small>
-        </h1>
+        <h1>Results <small class="badge">{{ results.length || 0 }}</small></h1>
       </div>
 
       <p class="lead">This is a second view in our angular app. This view displays the results of the search. Click here to return to our <a class="home" href="!">search page</a></p>

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ dependencies:
 test:
   override:
     - grunt lint
-    - grunt test:unit:devlopment
+    - grunt test:unit:development
     - grunt test:unit:production
   post:
     - ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info

--- a/circle.yml
+++ b/circle.yml
@@ -27,8 +27,8 @@ dependencies:
 test:
   override:
     - grunt lint
-    - grunt test:development
-    - grunt test
+    - grunt test:unit:devlopment
+    - grunt test:unit:production
   post:
     - ./node_modules/coveralls/bin/coveralls.js < coverage/lcov.info
 

--- a/circle.yml
+++ b/circle.yml
@@ -26,6 +26,7 @@ dependencies:
 
 test:
   override:
+    - grunt lint
     - grunt test:development
     - grunt test
   post:

--- a/modules/grid/index.html
+++ b/modules/grid/index.html
@@ -26,13 +26,13 @@
   <div class="container">
     <div class="row">
       <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12"><pre class="box">.col-lg-12 .col-md-12 .col-sm-12 .col-xs-12</pre></div>
-      <div class="col-lg-12 col-md-12 col-sm-12 col-xs-6 "><pre class="box">.col-lg-12 .col-md-12 .col-sm-12 .col-xs-6 </pre></div>
-      <div class="col-lg-6  col-md-6  col-sm-6  col-xs-6 "><pre class="box">.col-lg-6  .col-md-6  .col-sm-6  .col-xs-6 </pre></div>
+      <div class="col-lg-12 col-md-12 col-sm-12 col-xs-6"> <pre class="box">.col-lg-12 .col-md-12 .col-sm-12 .col-xs-6 </pre></div>
+      <div class="col-lg-6  col-md-6  col-sm-6  col-xs-6"> <pre class="box">.col-lg-6  .col-md-6  .col-sm-6  .col-xs-6 </pre></div>
       <div class="col-lg-6  col-md-6  col-sm-6  col-xs-12"><pre class="box">.col-lg-6  .col-md-6  .col-sm-6  .col-xs-12</pre></div>
       <div class="col-lg-4  col-md-4  col-sm-4  col-xs-12"><pre class="box">.col-lg-4  .col-md-4  .col-sm-4  .col-xs-12</pre></div>
       <div class="col-lg-4  col-md-4  col-sm-4  col-xs-12"><pre class="box">.col-lg-4  .col-md-4  .col-sm-4  .col-xs-12</pre></div>
-      <div class="col-lg-4  col-md-4  col-sm-4  col-xs-6 "><pre class="box">.col-lg-4  .col-md-4  .col-sm-4  .col-xs-6 </pre></div>
-      <div class="col-lg-3  col-md-3  col-sm-3  col-xs-6 "><pre class="box">.col-lg-3  .col-md-3  .col-sm-3  .col-xs-6 </pre></div>
+      <div class="col-lg-4  col-md-4  col-sm-4  col-xs-6"> <pre class="box">.col-lg-4  .col-md-4  .col-sm-4  .col-xs-6 </pre></div>
+      <div class="col-lg-3  col-md-3  col-sm-3  col-xs-6"> <pre class="box">.col-lg-3  .col-md-3  .col-sm-3  .col-xs-6 </pre></div>
       <div class="col-lg-3  col-md-3  col-sm-3  col-xs-12"><pre class="box">.col-lg-3  .col-md-3  .col-sm-3  .col-xs-12</pre></div>
       <div class="col-lg-3  col-md-3  col-sm-3  col-xs-12"><pre class="box">.col-lg-3  .col-md-3  .col-sm-3  .col-xs-12</pre></div>
       <div class="col-lg-3  col-md-3  col-sm-3  col-xs-12"><pre class="box">.col-lg-3  .col-md-3  .col-sm-3  .col-xs-12</pre></div>

--- a/modules/index.html
+++ b/modules/index.html
@@ -8,47 +8,24 @@
 
   <link rel="stylesheet" href="/app/components/bootstrap/dist/css/bootstrap.css">
 
-  <style>
-
-    h1 {
-      font-size: 32px;
-    }
-
-    h2 {
-      font-size: 24px;
-    }
-    ul,li {
-      list-style: none;
-      margin: 0;
-      padding: 0;
-    }
-
-    li {
-      margin: 1em;
-    }
-
-  </style>
-
 </head>
 <body>
   <div class="container">
     <div class="row">
       <div class="col-lg-12 col-md-12 col-sm-12 col-xs-12">
 
-
-        <h1>Testing Modules</h1>
-        <hr>
+        <div class="page-header">
+          <h1>Prototype Modules</h1>
+        </div>
 
         <h2>CSS Modules</h2>
-        <ul>
-          <li><a class="btn btn-primary" href="grid/">Grid System</a></li>
-          <li><a class="btn btn-primary" href="typography/">Typography</a></li>
-
+        <ul class="list-unstyled">
+          <li><a class="btn btn-primary" href="grid/">Grid System</a></li><br>
+          <li><a class="btn btn-primary" href="typography/">Typography</a></li><br>
         </ul>
-        <hr>
 
         <h2>JS Modules</h2>
-        <ul>
+        <ul class="list-unstyled">
 
         </ul>
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "yuidoc-bootstrap-theme": "~1.0.4"
   },
   "scripts": {
-    "postinstall": "bower install"
+    "postinstall": "bower install",
+    "test": "grunt test:unit:development"
   }
 }


### PR DESCRIPTION
This PR includes the following updates the build process:

- Disable `qualified-headings` options in `lesslint` task as bootstrap doesn't follow this rule.
- Allow `style` tag in `htmllint` for use in modules prototype pages.
- Split `grunt watch` tasks into smaller tasks so only the nessesary tasks are called when updating files.
- Move `.csslintrc` and `.htmllint` files into project root like `jshintrc` so easier to find.
- Lint html files in `modules` folder as well
- Remove `grunt serverjs` task as `grunt serverall` task does the same thing if only working on javascript
- Make `grunt server` task run all watch tasks just like with `grunt serverall`. 
- Move all linting to it's own grunt task which is run in circle and travis as well.
- Minor html formatting